### PR TITLE
[Add]: asynchronously flush memtable and use aux memtable for answering reads while doing that

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Go-CaskDB is a disk-based, embedded, persistent, key-value store based on the [R
 - [ ] Crash Safety with WAL
 - [ ] RB-tree to support range scans
 - [ ] Benchmarking
-- [ ] Cache (LRU? EXPLORE!)
+- [ ] Cache (Block + Table)
+- [ ] Bloom filter for fast non-existent key reads
 - [ ] Distributed using Paxos or consistent hashing
 
 

--- a/README_AT_UR_OWN_RISK.md
+++ b/README_AT_UR_OWN_RISK.md
@@ -74,6 +74,9 @@ Mostly contains stuff where I debate with myself on which design / lib / ... is 
 - But zap is json-like (not very good looking for devevelopment purpose)
 - Removing zap and going on with logrus (may come back later for production level logs)
 
+## Data race here, data race there, data race everywhere :)
+- Should think about properly preventing data races
+- Right now just used sync.Mutex but there are other options as sync.RWMutex --> should check if this would replace normal Mutex and enhance performance
 
 
 

--- a/README_AT_UR_OWN_RISK.md
+++ b/README_AT_UR_OWN_RISK.md
@@ -25,12 +25,63 @@ Mostly contains stuff where I debate with myself on which design / lib / ... is 
 - Load memtable at db start for the latest segment
 
 
+### Merge Compaction (!!!!! Most important)
+- Referring [3]. 
+- Merging is a NP-Hard problem.
+- Problem is formulated as merging N sets into 1. Each set is $A\subscript{i}
+- Cost is Sum ( | A[i] | + 2* | A[v] | + | A[root] | ) where v is middle non-leaf nodes in binary tree
+- Considering 4 greedy heuristic algorithms from the paper
+    - BALANCETREE 
+    - SMALLESTINPUT 
+    - SMALLESTOUTPUT 
+    - LARGESTMATCH
+
+    #### BALANCE TREE
+    - LogN + 1 - Approximation ==> lower bound is atleast Logn + 1 times OPT, where OPT is optimal time
+
+    #### SMALLEST INPUT
+    - Just take smaller sets in each iteration to defer the bigger sets
+
+    #### SMALLEST OUTPUT
+    - In each interation, choose 2 sets whose output is minimum 
+
+    ### LARGEST MATCH
+    - Each iteration, take 2 sets who have the largest intersection
+    - Worst case complexity can be arbitrarily bad
+  
+- Going with SMALLEST INPUT merging method as it provides LogN Approximation and way easier to implement compared to others.
+- Major part of manifest has to be changed to maintain the list of segment names, created timestamp and their cardinality (compute while inserting them itself)
+- While performing merge compaction of N segments, where N is configurable, following things are to be considered
+    - Their merged segment size should'nt cross certain size limit
+    - ~~Timestamp of newest merged segment = max (timestamps of all segments considered for merging)~~
+    - Timestamps doesn't work as the difference to fill another 4kb memtable is very very small. Going with just incremental segmentId for this
+    - For a new segment, segment id would be max(all segment id's) + 1
+    - For a merged segment, segment id = max(all merged segments)
+    - Cardinality is simple
+- When to perform merge compaction on the background? when total number of segments become more than N
+- Segments should be named according to segment id
+- Is it better to hold the *os.File of db manifest file as long as program is running? Reason being we have to read and write from segment file so many times and opening and closing it everytime might be in-effficient 
+- Referring [BigTable]
+
+
+### Caching
+- Can have 2 kinds of caches - Block and Table
+- Block cache is a LRU cache which contains the recently seeked keys and has an upper memory limit (configurable) 
+- Table cache stores the recently seeked file descriptors of Segment files (configurable)
+
 ## Logging
 - Uber zap seems to be amazingly fast. [Reference](https://www.sobyte.net/post/2022-03/uber-zap-advanced-usage/)
 - But zap is json-like (not very good looking for devevelopment purpose)
 - Removing zap and going on with logrus (may come back later for production level logs)
 
 
+
+
+
 ## Things that I found resourceful
-- [Blog #1](https://silhding.github.io/2021/08/20/A-Closer-Look-to-a-Key-Value-Storage-Engine/)
-- [My own notes](https://abesheknotes.netlify.app/docs/designing-data-intensive-applications/3-storage-and-retrieval/)
+- [1] [Blog #1](https://silhding.github.io/2021/08/20/A-Closer-Look-to-a-Key-Value-Storage-Engine/)
+- [2] [My own notes](https://abesheknotes.netlify.app/docs/designing-data-intensive-applications/3-storage-and-retrieval/)
+- [3] [Optimal Merge Compaction](https://www.researchgate.net/publication/283780735_Fast_Compaction_Algorithms_for_NoSQL_Databases)
+- [4] [Merge Compaction in BigTable](https://arxiv.org/pdf/1407.3008.pdf)
+- [5] [An In-depth Discussion on the LSM Compaction Mechanism](https://www.alibabacloud.com/blog/an-in-depth-discussion-on-the-lsm-compaction-mechanism_596780)
+- [6] [Facebook's RocksDB](https://github.com/facebook/rocksdb/wiki/RocksDB-Overview)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"runtime"
 
 	config "github.com/abesheknarayan/go-caskdb/pkg/config"
 	store "github.com/abesheknarayan/go-caskdb/pkg/disk_store"
@@ -14,8 +13,6 @@ func main() {
 
 	config.LoadConfigFromEnv()
 	utils.InitLogger()
-
-	runtime.GOMAXPROCS(2)
 
 	booksDb, err := store.InitDb("test1")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"runtime"
 
 	config "github.com/abesheknarayan/go-caskdb/pkg/config"
 	store "github.com/abesheknarayan/go-caskdb/pkg/disk_store"
@@ -14,12 +15,14 @@ func main() {
 	config.LoadConfigFromEnv()
 	utils.InitLogger()
 
-	booksDb, err := store.InitDb("test")
+	runtime.GOMAXPROCS(2)
+
+	booksDb, err := store.InitDb("test1")
 	if err != nil {
 		log.Fatalf("Failed to initialize DB %v", err)
 	}
 
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 1000; i++ {
 		// key := utils.GetRandomString(rand.Int()%10 + 1)
 		// value := utils.GetRandomString(rand.Int()%10 + 1)
 		key := fmt.Sprintf("Key %d", i+1)
@@ -28,6 +31,13 @@ func main() {
 		booksDb.Put(key, value)
 	}
 
+	utils.Logger.Debugln(booksDb.Get("Key 123"))
+	utils.Logger.Debugln(booksDb.Get("Key 33"))
+
+	utils.Logger.Debugln(booksDb.Get("Key 477"))
+	utils.Logger.Debugln(booksDb.Get("Key 1"))
+	utils.Logger.Debugln(booksDb.Get("Key 930"))
+
 	booksDb.CloseDB()
-	// booksDb.Cleanup()
+	booksDb.Cleanup()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,8 +10,9 @@ import (
 )
 
 type ConfigStruct struct {
-	Stage string // Dev || Prod || Test
-	Path  string
+	Stage                string // Dev || Prod || Test
+	Path                 string
+	MergeCompactionLimit uint32
 }
 
 var Config *ConfigStruct
@@ -39,8 +40,9 @@ func LoadConfigFromEnv() {
 		}
 	}
 	Config = &ConfigStruct{
-		Stage: stage,
-		Path:  path,
+		Stage:                stage,
+		Path:                 path,
+		MergeCompactionLimit: NUMBER_OF_SEGMENTS_FOR_MERGE_COMPACTION,
 	}
 	fmt.Println(Config)
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,0 +1,3 @@
+package config
+
+const NUMBER_OF_SEGMENTS_FOR_MERGE_COMPACTION uint32 = 5 // random, configurable

--- a/pkg/disk_store/disk_store.go
+++ b/pkg/disk_store/disk_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/abesheknarayan/go-caskdb/pkg/config"
@@ -17,18 +18,26 @@ import (
 
 // // for now, support keys and values only with string type
 
+// contains the metadata of segment files which goes in the manifest file
+type SegmentMetadata struct {
+	SegmentId   uint32
+	Cardinality uint32 // no of keys it contains
+}
+
 // contains the metdata of DB
 type Manifest struct {
-	DbName           string
-	NumberOfSegments uint32 // number of segments created till now
+	DbName   string
+	Segments []SegmentMetadata // should always be sorted according to SegmentId
 }
 
 type HashIndex map[string]KeyEntry.KeyEntry
 
 type DiskStore struct {
-	Manifest  *Manifest
-	HashIndex HashIndex // map of any value type
-	Memtable  *memtable.MemTable
+	Manifest          *Manifest
+	ManifestFile      *os.File  // holding the file to prevent unnecessary opening and closing everytime [subject to change in future]
+	HashIndex         HashIndex // map of any value type
+	Memtable          *memtable.MemTable
+	AuxillaryMemtable *memtable.MemTable // memtable is copied to this while its being written asynchronously to disk
 }
 
 // creates a new db and returns the object ref
@@ -55,7 +64,7 @@ func InitDb(dbName string) (*DiskStore, error) {
 	}
 
 	// if db manifest file is already present load it or else create new db
-	manifestFile := fmt.Sprintf("%s/%s.json", dirPath, dbName)
+	manifestFile := fmt.Sprintf("%s/manifest.json", dirPath)
 
 	if _, err := os.Stat(manifestFile); errors.Is(err, os.ErrNotExist) {
 		l.Infoln("file doesn't exist !!")
@@ -63,13 +72,7 @@ func InitDb(dbName string) (*DiskStore, error) {
 	}
 
 	// open manifest file in rw mode
-	f, err := os.OpenFile(manifestFile, os.O_RDONLY, 0666)
-	defer func() {
-		err = f.Close()
-		if err != nil {
-			l.Fatalln(err)
-		}
-	}()
+	f, err := os.OpenFile(manifestFile, os.O_RDWR, 0666)
 
 	if err != nil {
 		// prolly os error
@@ -78,20 +81,16 @@ func InitDb(dbName string) (*DiskStore, error) {
 
 	manifest := LoadManifest(f)
 
-	var segmentNumber uint32
-	if manifest.NumberOfSegments > 0 {
-		segmentNumber = manifest.NumberOfSegments
-	} else {
-		segmentNumber = manifest.NumberOfSegments + 1
-	}
-
 	d := &DiskStore{
-		Manifest:  manifest,
-		HashIndex: HashIndex{},
-		Memtable:  memtable.GetNewMemTable(dbName, segmentNumber),
+		Manifest:          manifest,
+		ManifestFile:      f,
+		HashIndex:         HashIndex{},
+		Memtable:          memtable.GetNewMemTable(dbName),
+		AuxillaryMemtable: nil,
 	}
 
-	d.Memtable.LoadFromSegmentFile()
+	// load the most recent segment file onto memtable
+	d.Memtable.LoadFromSegmentFile(d.Manifest.Segments[len(d.Manifest.Segments)-1].SegmentId)
 
 	// TODO
 	// d.loadHashIndex()
@@ -117,7 +116,7 @@ func LoadManifest(f *os.File) *Manifest {
 	return manifest
 }
 
-// create new file
+// create new db
 func createDb(dbName string, dbPath string) (*DiskStore, error) {
 
 	var l = utils.Logger.WithFields(logrus.Fields{
@@ -128,7 +127,7 @@ func createDb(dbName string, dbPath string) (*DiskStore, error) {
 	l.Infoln("Attempting to create a database")
 
 	// first create manifest file
-	filename := fmt.Sprintf("%s/%s.json", dbPath, dbName)
+	filename := fmt.Sprintf("%s/manifest.json", dbPath)
 	l.Infof("creating new file %s\n", filename)
 	manifestFile, err := os.Create(filename)
 
@@ -137,8 +136,8 @@ func createDb(dbName string, dbPath string) (*DiskStore, error) {
 	}
 
 	manifest := &Manifest{
-		DbName:           dbName,
-		NumberOfSegments: 0,
+		DbName:   dbName,
+		Segments: []SegmentMetadata{},
 	}
 
 	if err != nil {
@@ -149,9 +148,11 @@ func createDb(dbName string, dbPath string) (*DiskStore, error) {
 	encoder.Encode(manifest)
 
 	d := &DiskStore{
-		Manifest:  manifest,
-		HashIndex: HashIndex{},
-		Memtable:  memtable.GetNewMemTable(dbName, manifest.NumberOfSegments+1),
+		Manifest:          manifest,
+		ManifestFile:      manifestFile,
+		HashIndex:         HashIndex{},
+		Memtable:          memtable.GetNewMemTable(dbName),
+		AuxillaryMemtable: nil,
 	}
 
 	// TODO
@@ -166,23 +167,44 @@ func createDb(dbName string, dbPath string) (*DiskStore, error) {
 func (d *DiskStore) Put(key string, value string) {
 
 	var l = utils.Logger.WithFields(logrus.Fields{
-		"method":      "Set",
+		"method":      "Put",
 		"param_key":   key,
 		"param_value": value,
 	})
 	l.Infof("Attempting to set a key")
 
 	if err := d.Memtable.Put(key, value); errors.Is(err, CustomError.MaxSizeExceedError) {
-		err = d.Memtable.WriteMemtableToDisk()
+		// copy memtable to aux memtable
+		// since it's a pointer just change the pointers
 
-		if err != nil {
-			l.Fatalln(err)
+		// if its not nil then before auxillary memtable is waiting to write its contents to file and got blocked because of file write. So we block the main go routine so that, the auxillary file write finishes before executing further
+		// Important point to note here is that, during the time between auxillary go routine waiting to write to this step in the next run, all writes and reads are supported using memtable and aux memtable so no issues with reads and writes
+		if d.AuxillaryMemtable != nil {
+			l.Debugln("Waiting for aux memtable write to disk to finish")
+			d.AuxillaryMemtable.Wg.Wait()
 		}
+		l.Debugln("Writing memtable to aux")
+		d.AuxillaryMemtable = d.Memtable
+		d.Memtable = memtable.GetNewMemTable(d.Manifest.DbName)
 
-		d.Manifest.NumberOfSegments += 1
-		d.ChangeManifestFileContent(d.Manifest.NumberOfSegments)
-
-		d.Memtable = memtable.GetNewMemTable(d.Manifest.DbName, d.Manifest.NumberOfSegments+1)
+		// async
+		go func() {
+			// find segment id
+			l.Debugln("Writing Auxillary memtable to disk")
+			l.Debugln(d.AuxillaryMemtable)
+			d.AuxillaryMemtable.Wg.Add(1)
+			segmentId := d.GetNewSegmentId()
+			cardinality, err := d.AuxillaryMemtable.WriteMemtableToDisk(segmentId)
+			if err != nil {
+				l.Fatalln(err)
+			}
+			d.Manifest.Segments = append(d.Manifest.Segments, SegmentMetadata{
+				SegmentId:   segmentId,
+				Cardinality: cardinality,
+			})
+			d.ChangeNumberOfSegmentsInManifest()
+			d.AuxillaryMemtable.Wg.Done()
+		}()
 
 		// again call
 		d.Memtable.Put(key, value)
@@ -198,36 +220,55 @@ func (d *DiskStore) Get(key string) string {
 	value, err := d.Memtable.Get(key)
 
 	if err != nil && errors.Is(err, CustomError.KeyDoesNotExistError) {
-		// check all the segments one by one from the most recent
-		value, err = d.CheckAllSegmentsOneByOne(key, d.Manifest.NumberOfSegments)
+		// check auxillary memtable
 
-		if err != nil && errors.Is(err, CustomError.KeyDoesNotExistError) {
-			return ""
+		if d.AuxillaryMemtable != nil {
+
+			value, err = d.AuxillaryMemtable.Get(key)
+
+			if err != nil && errors.Is(err, CustomError.KeyDoesNotExistError) {
+				// check all the segments one by one from the most recent
+
+				value, err = d.CheckAllSegmentsOneByOne(key, int(len(d.Manifest.Segments)-1))
+
+				if err != nil && errors.Is(err, CustomError.KeyDoesNotExistError) {
+					return ""
+				}
+			}
+			return value
 		}
 	}
 
 	return value
 }
 
-func (d *DiskStore) CheckAllSegmentsOneByOne(key string, segmentNumber uint32) (string, error) {
+// Returns the most recent segment id plus 1 from the disk store
+func (d *DiskStore) GetNewSegmentId() uint32 {
+	if len(d.Manifest.Segments) == 0 {
+		return 1
+	}
+	return d.Manifest.Segments[len(d.Manifest.Segments)-1].SegmentId + 1
+}
+
+func (d *DiskStore) CheckAllSegmentsOneByOne(key string, segmentIndex int) (string, error) {
 
 	var l = utils.Logger.WithFields(logrus.Fields{
 		"method":              "CheckAllSegmentsOneByOne",
 		"param_key":           key,
-		"param_segmentNumber": segmentNumber,
+		"param_segmentNumber": segmentIndex,
 	})
-	if segmentNumber == 0 {
+	if segmentIndex < 0 {
 		return "", CustomError.KeyDoesNotExistError
 	}
-	l.Infof("Attempting to check segment file %d for key %s", segmentNumber, key)
+	l.Infof("Attempting to check segment file %d for key %s", segmentIndex, key)
 
-	memtable := memtable.GetNewMemTable(d.Manifest.DbName, segmentNumber)
-	memtable.LoadFromSegmentFile()
+	memtable := memtable.GetNewMemTable(d.Manifest.DbName)
+	memtable.LoadFromSegmentFile(d.Manifest.Segments[segmentIndex].SegmentId)
 
 	value, err := memtable.Get(key)
 	if err != nil && errors.Is(err, CustomError.KeyDoesNotExistError) {
 		// check before segment file recursively
-		return d.CheckAllSegmentsOneByOne(key, segmentNumber-1)
+		return d.CheckAllSegmentsOneByOne(key, segmentIndex-1)
 	}
 
 	return value, nil
@@ -239,7 +280,9 @@ func (d *DiskStore) Cleanup() {
 		"method": "Cleanup",
 	})
 	l.Infoln("Cleaning up the database")
-	d.Manifest.NumberOfSegments = 0
+
+	// clear the segments slice
+	d.Manifest.Segments = d.Manifest.Segments[:0]
 
 	// delete everything including manifest file
 
@@ -251,29 +294,28 @@ func (d *DiskStore) Cleanup() {
 	}
 }
 
-func (d *DiskStore) ChangeManifestFileContent(numberOfSegments uint32) {
+func (d *DiskStore) ChangeNumberOfSegmentsInManifest() {
 	var l = utils.Logger.WithFields(logrus.Fields{
-		"method":                 "ChangeManifestFileContent",
-		"param_numberOfSegments": numberOfSegments,
+		"method": "ChangeNumberOfSegmentsInManifest",
 	})
-	path := config.Config.Path
-	// modify manifest
-	manifestFilePath := fmt.Sprintf("%s/%s/%s.json", path, d.Manifest.DbName, d.Manifest.DbName)
-
-	manifestFile, err := os.OpenFile(manifestFilePath, os.O_RDWR, 0666)
+	err := d.ManifestFile.Truncate(0)
 
 	if err != nil {
-		l.Errorf("Error in opening manifest file %v", err)
+		l.Panicf("Error in truncating manifest file %v", err)
 	}
 
-	manifest := &Manifest{
-		DbName:           d.Manifest.DbName,
-		NumberOfSegments: numberOfSegments,
+	marshalledManifest, err := json.Marshal(d.Manifest)
+	if err != nil {
+		l.Panicf("Error in marshalling  manifest obejct %v", err)
 	}
-	manifestFile.Truncate(0)
 
-	encoder := json.NewEncoder(manifestFile)
-	encoder.Encode(manifest)
+	manifestFile := fmt.Sprintf("%s/%s/manifest.json", config.Config.Path, d.Manifest.DbName)
+	// err = encoder.Encode(manifest)
+	err = ioutil.WriteFile(manifestFile, marshalledManifest, 0666)
+
+	if err != nil {
+		l.Panicf("Error in writing to manifest file %v", err)
+	}
 }
 
 // Deletes the contents of memtable
@@ -284,6 +326,18 @@ func (d *DiskStore) CloseDB() {
 	l.Infoln("Closing the database")
 
 	// write memtable to segment file and clear it
-	d.Memtable.WriteMemtableToDisk()
+	segmentId := d.GetNewSegmentId()
+	cardinality, err := d.Memtable.WriteMemtableToDisk(segmentId)
+	if err != nil {
+		l.Fatalf("Error while writing memtable to disk %v", err)
+	}
+	d.Manifest.Segments = append(d.Manifest.Segments, SegmentMetadata{
+		SegmentId:   segmentId,
+		Cardinality: cardinality,
+	})
+	d.ChangeNumberOfSegmentsInManifest()
 	d.Memtable.Clear()
+
+	// close manifest file
+	d.ManifestFile.Close()
 }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 echo "...running unit tests..."
 export CASKDB_ENV=Test
-go test -run="^(Test|Benchmark)[^_](.*)" ./... 
+go test -race -run="^(Test|Benchmark)[^_](.*)" ./... 
 code=$?
 
 if [ $code -ne 0 ]; then
@@ -11,7 +11,7 @@ printf "\nUnit Tests complete. Performing Integration Tests now.\n"
 
 echo "...running integration tests..."
 
-go test -v -run="^(Test|Benchmark)_(.*)" ./...
+go test -v -race -run="^(Test|Benchmark)_(.*)" ./...
 code=$?
 
 exit $code


### PR DESCRIPTION
### In this PR
- Modify the db segments using segement id and store them (segment ids) in an array in manifest file. This is helpful in doing merge compaction in the upcoming prs.
- Asynchrounously write memtable to disk (it was synchrounous earlier). To facilitate reads during that period (while writing to disk), have an auxillary memtable whose contents can be read (contains the previous memtable data which is being written to disk async..ly now) while newer memtable is being used for new writes.
- Prevent data races in segment portion of manifest (as this would be constantly be read and written by go routines) using `sync.Mutex`